### PR TITLE
feat: Copy Liked Songs to a playlist with new script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 
 # PyCharm
 .idea/
+
+.env

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This script prints all tracks from a Spotify playlist. It supports playlists wit
 limit (100 songs), making multiple requests.
 
 In the first line, it shows the name of the playlist and the number of songs. Then, after a blank line, it shows one
-song per line, with the list of artists sepparated with commas and the name of the song.
+song per line, with the list of artists separated with commas and the name of the song.
 
 This is the first script I wrote as I started tinkering with spotipy, and it probably doesn't have much practical use.
 
@@ -92,6 +92,8 @@ Tchami, Marten Hørger — The Calling
 Alok, Bastille — Run Into Trouble
 Jax Jones, Martin Solveig, GRACEY, Europa — Lonely Heart
 ```
+
+Instead of a playlist id you can pass `saved` to get your Liked Songs list. 
 
 ### [create_playlist_mix](https://github.com/albertored11/spotipy-scripts/blob/main/scripts/create_playlist_mix.py)
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ listen to them later.
 The playlist IDs (source and destination) are read from the first and the second program arguments, respectively:
 
 ```bash
-python scripts/get_playlist_tracks.py <source_playlist_id> <dest_playlist_id>
+python scripts/copy_to_playlist.py <source_playlist_id> <dest_playlist_id>
 ```
 
 Running the script would append the tracks from the playlist with ID `<source_playlist_id>` to the end of the playlist
@@ -343,3 +343,21 @@ the script once a week.
 
 My choice is using a [systemd timer](https://wiki.archlinux.org/title/Systemd/Timers) to run the script every friday at
 12:00, but a cron job should also do the work.
+
+### [copy_saved_to_playlist](blob/main/scripts/copy_saved_to_playlist.py)
+
+This script takes the tracks from the Liked Songs playlist and appends them to the end of a different, existing 
+playlist, avoiding duplicates.
+
+The reason I wrote this script is that the Spotify mobile app seems to slow down and malfunction when the Liked
+Songs list becomes very large. This script allows me to copy that Liked Songs list over to an archive list and 
+remove a few thousand songs from the Liked list, making my experience in the app significantly better. 
+
+The playlist ID (destination) is read from the first program argument:
+
+```bash
+python scripts/copy_saved_to_playlist.py <dest_playlist_id>
+```
+
+Running the script would append the tracks from the playlist with ID `<source_playlist_id>` to the end of the playlist
+with ID `<dest_playlist_id>`, excepting the ones that already existed in the latter.

--- a/scripts/copy_saved_to_playlist.py
+++ b/scripts/copy_saved_to_playlist.py
@@ -1,0 +1,63 @@
+# Script that takes the tracks from a playlist and appends them to the end of a different, existing playlist
+# Requires: spotipy
+# Usage: python copy_to_playlist.py <source_playlist_id> <dest_playlist_id>
+# Set SPOTIPY_CLIENT_ID and SPOTIPY_CLIENT_SECRET environment variables
+# Set SPOTIPY_REDIRECT_URI environment variable (e. g. to http://localhost:9090)
+
+import spotipy
+import sys
+from spotipy.oauth2 import SpotifyOAuth
+
+if len(sys.argv) < 2:
+    print("Usage: python copy_to_playlist.py <source_playlist_id> <dest_playlist_id>", file=sys.stderr)
+    exit(1)
+
+# Define needed scopes:
+# * playlist-read-collaborative: to get tracks from collab playlists
+# * playlist-read-private: to get tracks from private playlists
+# * playlist-modify-private: to create the playlist and add tracks to it
+scope = "playlist-read-collaborative playlist-read-private playlist-modify-private user-library-read"
+
+# Set up auth using Authorization Code Flow
+sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
+
+source_playlist_id = sys.argv[1]
+dest_playlist_id = sys.argv[2]
+
+offset = 0  # Keep an offset bc requests have a 100 track limit
+source_playlist_song_ids = []  # List for the songs from source playlist
+dest_playlist_song_ids = []  # List for the songs from destination playlist
+
+# Request tracks from destination playlist
+items = sp.playlist_items(dest_playlist_id, limit=100)['items']
+
+# Iterate while getting items from the request
+while len(items) > 0:
+    for item in items:
+        dest_playlist_song_ids.append(item['track']['id'])  # Append the ID of the track
+
+    # Request next 100 items
+    offset += 100
+    items = sp.playlist_items(dest_playlist_id, limit=100, offset=offset)['items']
+
+offset = 0  # Reset offset
+
+# Request tracks from source playlist
+items = sp.current_user_saved_tracks(limit=50, offset=0, market="US")['items']
+
+# Iterate while getting items from the request
+while len(items) > 0:
+    for item in items:
+        source_playlist_song_ids.append(item['track']['id'])  # Append the ID of the track
+
+    # Request next 100 items
+    offset += 50
+    items = sp.current_user_saved_tracks(limit=50, offset=offset, market="US")['items']
+
+# Remove tracks that already are in destination playlist to avoid duplicates
+source_playlist_song_ids = [x for x in source_playlist_song_ids if x not in dest_playlist_song_ids]
+
+# Add tracks to the destination playlist 100 by 100 due to the limit
+while len(source_playlist_song_ids) > 0:
+    sp.playlist_add_items(dest_playlist_id, source_playlist_song_ids[:100])
+    source_playlist_song_ids = source_playlist_song_ids[100:]

--- a/scripts/copy_saved_to_playlist.py
+++ b/scripts/copy_saved_to_playlist.py
@@ -1,6 +1,6 @@
-# Script that takes the tracks from a playlist and appends them to the end of a different, existing playlist
+# Script that takes the tracks from your Liked Songs and appends them to the end of a different, existing playlist
 # Requires: spotipy
-# Usage: python copy_to_playlist.py <source_playlist_id> <dest_playlist_id>
+# Usage: python copy_to_playlist.py <dest_playlist_id>
 # Set SPOTIPY_CLIENT_ID and SPOTIPY_CLIENT_SECRET environment variables
 # Set SPOTIPY_REDIRECT_URI environment variable (e. g. to http://localhost:9090)
 
@@ -16,13 +16,13 @@ if len(sys.argv) < 2:
 # * playlist-read-collaborative: to get tracks from collab playlists
 # * playlist-read-private: to get tracks from private playlists
 # * playlist-modify-private: to create the playlist and add tracks to it
+# * user-library-read: to read the Liked playlist and get tracks from it
 scope = "playlist-read-collaborative playlist-read-private playlist-modify-private user-library-read"
 
 # Set up auth using Authorization Code Flow
 sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
 
-source_playlist_id = sys.argv[1]
-dest_playlist_id = sys.argv[2]
+dest_playlist_id = sys.argv[1]
 
 offset = 0  # Keep an offset bc requests have a 100 track limit
 source_playlist_song_ids = []  # List for the songs from source playlist
@@ -42,7 +42,8 @@ while len(items) > 0:
 
 offset = 0  # Reset offset
 
-# Request tracks from source playlist
+# Request tracks from source Liked playlist
+# Note: Liked Playlist has a limit of 50 tracks per request 
 items = sp.current_user_saved_tracks(limit=50, offset=0, market="US")['items']
 
 # Iterate while getting items from the request
@@ -50,7 +51,7 @@ while len(items) > 0:
     for item in items:
         source_playlist_song_ids.append(item['track']['id'])  # Append the ID of the track
 
-    # Request next 100 items
+    # Request next 50 items
     offset += 50
     items = sp.current_user_saved_tracks(limit=50, offset=offset, market="US")['items']
 

--- a/scripts/get_playlist_tracks.py
+++ b/scripts/get_playlist_tracks.py
@@ -44,13 +44,13 @@ else:
     print(playlist['name'] + " — " + str(track_total) + " tracks\n")
 
 offset = 0  # Keep an offset bc requests have a 100 track limit
-
+count = 0
 # Iterate while getting items from the request
 while len(items) > 0:
     for item in items:
         track = item['track']
         artists = track['artists']
-
+        count += 1
         # If just one artist, print its name
         if len(artists) == 1:
             print(artists[0]['name'] + " — ", end="")
@@ -71,3 +71,6 @@ while len(items) > 0:
     else:
         offset += 100
         items = sp.playlist_items(playlist_id, limit=100, offset=offset)['items']
+
+
+print(count);


### PR DESCRIPTION
This branch builds out a new script to copy liked songs to a playlist via a new command in the style of those already in the repository.

The command replicates the `copy_to_playlist` script but uses the Liked Songs playlist as the source for the purpose of
creating an archive playlist that allows me to clean up the Liked Songs playlist for performance reasons.

It also adds the documentation for the new command into the README.

I also included some small cleanups for the README and a count output for `get_playlist_tracks` command. 

Thanks for all your great work here @albertored11 ! This is a really clearly put together repository with straightforward code that I found *really* useful and I basically just copied and made some small modifications to your work to create this new command, which is extremely useful for me. 